### PR TITLE
prettier/eslintを少し整理 #36

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/prettierrc",
   "semi": false,
   "tabWidth": 2,
-  "singleQuote": true,
+  "singleQuote": false,
   "printWidth": 100,
-  "trailingComma": "none"
+  "trailingComma": "all"
 }

--- a/README.md
+++ b/README.md
@@ -4,3 +4,37 @@
 
 # envファイルの準備
 - srcディレクトリと同じ階層に`.env.development`を作成し、その中に`VITE_API_SERVER_URI="http://localhost:8080"`というコードを貼り付けてください。
+
+  .env.development
+  ```text
+  VITE_API_SERVER_URI="http://localhost:8080"
+  ```
+
+### 動かない場合
+
+- ファイル名 `.env.development` の先頭に `.` (ドット)がついていることを確認する
+
+
+# その他開発環境について
+
+## Windows環境でHMR(ホットリロード)を動かしたい場合
+Windows + Docker + ViteだとViteのホットリロードが動かないっぽい｡
+vite.config.jsの `server` に `watch` を追加したら動いた｡
+
+vite.config.js
+```
+export default defineConfig({
+  ...
+  server: {
+    host: true,
+    watch: {
+      usePolling: true,
+      interval: 1000
+    }
+  },
+  ...
+```
+
+参考:
+https://zenn.dev/hctaw_srp/articles/1f7f67de03d710
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,18 @@ export default defineConfig({
 参考:
 https://zenn.dev/hctaw_srp/articles/1f7f67de03d710
 
+
+
+# PUSH時とか
+
+push前に以下のコマンドを実行してformat/lintする｡
+
+format
+```
+npm run format
+```
+
+lint
+```
+npm run lint
+```


### PR DESCRIPTION
- READMEに環境構築まわりの補足を追加
- readmeにpush前のlint/formatについて追記
  - vscodeの設定を追加
    - prettierをdefault formatterに指定
    - ファイル保存時に自動フォーマット

close #36 